### PR TITLE
fix mysql add sql

### DIFF
--- a/src/db-client/mysql.ts
+++ b/src/db-client/mysql.ts
@@ -61,8 +61,8 @@ class MySQLClient extends DBClient {
         throw new Error('duplicate password.')
       } else {
         await this.cl.query(
-          'INSERT INTO `users` VALUES(?, ?, -1, 0, 0) ON DUPLICATE KEY UPDATE `password` = ?',
-          [acctId, key, key],
+          'INSERT INTO `users` VALUES(?, ?, ?, -1, 0, 0) ON DUPLICATE KEY UPDATE `password` = ?',
+          [acctId, acctId, key, key],
         )
         return { type: ECommand.Add, id: acctId }
       }


### PR DESCRIPTION
According to the trojan tutorial to create a ‘users’ table format with six fields, you are missing one. I think maintaining the six fields of the tutorial is more friendly to new users.